### PR TITLE
Add debounce to global search

### DIFF
--- a/update_settings.lua
+++ b/update_settings.lua
@@ -1,0 +1,14 @@
+local args = {'hmset', settings_key}
+
+for i = num_static_argv + 1, #ARGV do
+  table.insert(args, ARGV[i])
+end
+
+redis.call(unpack(args))
+
+process_tick(now, true)
+
+local groupTimeout = tonumber(redis.call('hget', settings_key, 'groupTimeout'))
+refresh_expiration(0, 0, groupTimeout)
+
+return {}


### PR DESCRIPTION
Reduce redundant API calls and improve perceived performance by debouncing the global search input. This change adds a 300ms debounce to the search component, updates related unit tests, and ensures pending requests are cancelled on input change.